### PR TITLE
Get rid of weird warning when running tests

### DIFF
--- a/exercise7/nanodash/nanodash.py
+++ b/exercise7/nanodash/nanodash.py
@@ -177,11 +177,11 @@ class NanoDash:
             {"input_ids": input_ids, "output_ids": output_ids, "function": function}
         )
 
-    def run(self, debug=True) -> None:
+    def run(self, debug=True, **kwargs) -> None:
         """
         Run the NanoDash application by starting the Flask server.
         """
-        self.app.run(debug=debug)
+        self.app.run(debug=debug, **kwargs)
 
 
 def make_json_serializable(output_values: List) -> List:

--- a/test_utils.py
+++ b/test_utils.py
@@ -39,7 +39,7 @@ def start_server(script_path):
     
     # Create a thread to run the server
     server_thread = threading.Thread(
-        target=lambda: app.run()
+        target=lambda: app.run(use_reloader=False)
     )
     server_thread.daemon = True
     server_thread.start()


### PR DESCRIPTION
- It seems passing the argument `use_reloader=False` to Flask when running it in another thread for testing avoids the weird warning we were getting earlier